### PR TITLE
问题：网络断开之后不能启动rpc。

### DIFF
--- a/python/cbm/rpc/RpcClient.py
+++ b/python/cbm/rpc/RpcClient.py
@@ -7,7 +7,7 @@ from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol
 from thrift.server import TServer
 
-HOST = 'localhost'
+HOST = '127.0.0.1'
 PORT1, PORT2 = 9100, 9090
 
 #客户端封装类


### PR DESCRIPTION
解决：修改RpcClient.py中的HOST为127.0.0.1